### PR TITLE
Change module name

### DIFF
--- a/cmd/api-converter/main.go
+++ b/cmd/api-converter/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"asyncapi-converter/internal/cli"
+	"github.com/asyncapi/converter-go/internal/cli"
 	"github.com/docopt/docopt-go"
 
-	"asyncapi-converter/pkg/converter/v2"
+	"github.com/asyncapi/converter-go/pkg/converter/v2"
 
 	"fmt"
 	"log"

--- a/examples/json-to-yaml/string_converter.go
+++ b/examples/json-to-yaml/string_converter.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	v2 "asyncapi-converter/pkg/converter/v2"
-	"asyncapi-converter/pkg/decode"
-	"asyncapi-converter/pkg/encode"
+	v2 "github.com/asyncapi/converter-go/pkg/converter/v2"
+	"github.com/asyncapi/converter-go/pkg/decode"
+	"github.com/asyncapi/converter-go/pkg/encode"
 
 	"log"
 	"os"

--- a/examples/yaml-to-json/http_converter.go
+++ b/examples/yaml-to-json/http_converter.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	v2 "asyncapi-converter/pkg/converter/v2"
-	"asyncapi-converter/pkg/decode"
-	"asyncapi-converter/pkg/encode"
+	v2 "github.com/asyncapi/converter-go/pkg/converter/v2"
+	"github.com/asyncapi/converter-go/pkg/decode"
+	"github.com/asyncapi/converter-go/pkg/encode"
 
 	"log"
 	"net/http"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module asyncapi-converter
+module github.com/asyncapi/converter-go
 
 go 1.12
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,9 +4,9 @@ import (
 	"github.com/docopt/docopt-go"
 	"github.com/pkg/errors"
 
-	v2 "asyncapi-converter/pkg/converter/v2"
-	"asyncapi-converter/pkg/decode"
-	asyncapiEncode "asyncapi-converter/pkg/encode"
+	v2 "github.com/asyncapi/converter-go/pkg/converter/v2"
+	"github.com/asyncapi/converter-go/pkg/decode"
+	asyncapiEncode "github.com/asyncapi/converter-go/pkg/encode"
 
 	"fmt"
 	"io"

--- a/pkg/converter/v2/converter.go
+++ b/pkg/converter/v2/converter.go
@@ -1,7 +1,7 @@
 package v2
 
 import (
-	asyncapierr "asyncapi-converter/pkg/error"
+	asyncapierr "github.com/asyncapi/converter-go/pkg/error"
 
 	"fmt"
 	"io"

--- a/pkg/converter/v2/converter_test.go
+++ b/pkg/converter/v2/converter_test.go
@@ -1,8 +1,8 @@
 package v2
 
 import (
-	"asyncapi-converter/pkg/decode"
-	"asyncapi-converter/pkg/encode"
+	"github.com/asyncapi/converter-go/pkg/decode"
+	"github.com/asyncapi/converter-go/pkg/encode"
 	. "github.com/onsi/gomega"
 
 	"bytes"


### PR DESCRIPTION
In order to have a backward compatible package we need to change the module name from `asyncapi-converter` to `github.com/asyncapi/converter-go`