### PR TITLE
Add new DocumentVersionUpToDate error 

### DIFF
--- a/pkg/converter/v2/converter.go
+++ b/pkg/converter/v2/converter.go
@@ -251,8 +251,10 @@ func (c *converter) verifyAsyncapiVersion() error {
 		return asyncapierr.NewInvalidProperty("asyncapi")
 	}
 	versionString := fmt.Sprintf("%v", version)
-	switch versionRegexp.Match([]byte(versionString)) {
-	case true:
+	switch {
+	case versionString == AsyncapiVersion:
+		return asyncapierr.NewDocumentVersionUpToDate(AsyncapiVersion)
+	case versionRegexp.Match([]byte(versionString)):
 		return nil
 	default:
 		return asyncapierr.NewUnsupportedAsyncapiVersion(versionString)

--- a/pkg/converter/v2/converter_test.go
+++ b/pkg/converter/v2/converter_test.go
@@ -238,3 +238,65 @@ func readDataFromFile(converter Converter, filePath string, g *WithT) (*bytes.Bu
 	err = converter.Convert(resultReader, resultWriter)
 	return resultWriter, err
 }
+
+func TestVerifyAsyncapiVersion_no_error(t *testing.T) {
+	tests := []struct {
+		name, version string
+	}{
+		{
+			name:    "valid version 1.0.0",
+			version: "1.0.0",
+		},
+		{
+			name:    "valid version 1.1.0",
+			version: "1.1.0",
+		},
+		{
+			name:    "valid version 1.2.0",
+			version: "1.2.0",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			c := converter{
+				data: map[string]interface{}{
+					"asyncapi": test.version,
+				},
+			}
+			err := c.verifyAsyncapiVersion()
+			g.Expect(err).ShouldNot(HaveOccurred())
+		})
+	}
+}
+
+func TestVerifyAsyncapiVersion_error(t *testing.T) {
+	tests := []struct {
+		name      string
+		converter converter
+	}{
+		{
+			name: "document version is up to date",
+			converter: converter{
+				data: map[string]interface{}{
+					"asyncapi": AsyncapiVersion,
+				},
+			},
+		},
+		{
+			name: "invalid version 123.333333",
+			converter: converter{
+				data: map[string]interface{}{
+					"asyncapi": "123.333333",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := test.converter.verifyAsyncapiVersion()
+			g.Expect(err).Should(HaveOccurred())
+		})
+	}
+}

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -1,6 +1,8 @@
 package error
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type errType = int
 
@@ -8,6 +10,7 @@ const (
 	errInvalidProperty errType = iota + 1
 	errInvalidDocument
 	errUnsupportedAsyncapiVersion
+	errDocumentVersionUpToDate
 )
 
 type Error struct {
@@ -38,6 +41,10 @@ func IsUnsupportedAsyncapiVersion(err error) bool {
 	return isErrorType(errUnsupportedAsyncapiVersion, err)
 }
 
+func IsDocumentVersionUpToDate(err error) bool {
+	return isErrorType(errDocumentVersionUpToDate, err)
+}
+
 func newError(errType errType, msg string) Error {
 	return Error{
 		errType: errType,
@@ -57,4 +64,9 @@ func NewInvalidDocument() Error {
 func NewUnsupportedAsyncapiVersion(context interface{}) Error {
 	msg := fmt.Sprintf("asyncapi: unsupported asyncapi version '%v'", context)
 	return newError(errUnsupportedAsyncapiVersion, msg)
+}
+
+func NewDocumentVersionUpToDate(context interface{}) Error {
+	msg := fmt.Sprintf("asyncapi: document is already in version: %v", context)
+	return newError(errDocumentVersionUpToDate, msg)
 }

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -34,6 +34,11 @@ func TestIsInvalidPropertyErr(t *testing.T) {
 			error:    err,
 			expected: false,
 		},
+		{
+			name:     "DocumentVersionUpToDate",
+			error:    NewDocumentVersionUpToDate("test"),
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -65,6 +70,11 @@ func TestIsErrInvalidDocumentErr(t *testing.T) {
 		{
 			name:     "ErrUnsupportedAsyncapiVersion",
 			error:    NewUnsupportedAsyncapiVersion("test"),
+			expected: false,
+		},
+		{
+			name:     "DocumentVersionUpToDate",
+			error:    NewDocumentVersionUpToDate("test"),
 			expected: false,
 		},
 	}
@@ -100,11 +110,54 @@ func TestIsErrUnsupportedAsyncapiVersionErr(t *testing.T) {
 			error:    NewUnsupportedAsyncapiVersion("test"),
 			expected: true,
 		},
+		{
+			name:     "DocumentVersionUpToDate",
+			error:    NewDocumentVersionUpToDate("test"),
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(IsUnsupportedAsyncapiVersion(test.error)).To(Equal(test.expected))
+			if actual, ok := test.error.(Error); ok {
+				g.Expect(actual.Error()).ToNot(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestDocumentVersionUpToDateErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		error    error
+		expected bool
+	}{
+		{
+			name:     "ErrInvalidProperty",
+			error:    NewInvalidProperty("test"),
+			expected: false,
+		},
+		{
+			name:     "ErrInvalidDocument",
+			error:    NewInvalidDocument(),
+			expected: false,
+		},
+		{
+			name:     "ErrUnsupportedAsyncapiVersion",
+			error:    NewUnsupportedAsyncapiVersion("test"),
+			expected: false,
+		},
+		{
+			name:     "DocumentVersionUpToDate",
+			error:    NewDocumentVersionUpToDate("test"),
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(IsDocumentVersionUpToDate(test.error)).To(Equal(test.expected))
 			if actual, ok := test.error.(Error); ok {
 				g.Expect(actual.Error()).ToNot(BeEmpty())
 			}


### PR DESCRIPTION
Add a new error that will signal if the version of converted document is already up to date.