### PR TITLE
refactor: extracting options as constants

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,12 @@ var (
 	errInvalidArgument  = errors.New("invalid argument")
 )
 
+const (
+	encodeOptionYAML  = "--toYAML"
+	fileOptionPath = "<PATH>"
+	idOption = "--id"
+)
+
 type encode = func(interface{}, io.Writer) error
 
 // Converter converts an AsyncAPI document.
@@ -43,7 +49,7 @@ func New(opts docopt.Opts) Cli {
 }
 
 func (h Cli) id() *string {
-	idOption, ok := h.Opts["--id"]
+	idOption, ok := h.Opts[idOption]
 	if !ok || idOption == nil {
 		return nil
 	}
@@ -52,12 +58,12 @@ func (h Cli) id() *string {
 }
 
 func (h Cli) encode() (encode, error) {
-	if _, ok := h.Opts["--toYAML"]; !ok {
+	if _, ok := h.Opts[encodeOptionYAML]; !ok {
 		return asyncapiEncode.ToJSON, nil
 	}
-	toYaml, ok := h.Opts["--toYAML"].(bool)
+	toYaml, ok := h.Opts[encodeOptionYAML].(bool)
 	if !ok {
-		return nil, errors.Wrap(errInvalidArgument, "--toYAML")
+		return nil, errors.Wrap(errInvalidArgument, encodeOptionYAML)
 	}
 	if toYaml {
 		return asyncapiEncode.ToYaml, nil
@@ -71,7 +77,7 @@ func isURL(str string) bool {
 }
 
 func (h Cli) reader() (io.Reader, error) {
-	fileOption := h.Opts["<PATH>"]
+	fileOption := h.Opts[fileOptionPath]
 	path := fmt.Sprintf("%v", fileOption)
 	if isURL(path) {
 		resp, err := http.Get(path)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,9 +21,9 @@ var (
 )
 
 const (
-	encodeOptionYAML  = "--toYAML"
-	fileOptionPath = "<PATH>"
-	idOption = "--id"
+	optionEncodeYAML = "--toYAML"
+	optionFilePath = "<PATH>"
+	optionID       = "--id"
 )
 
 type encode = func(interface{}, io.Writer) error
@@ -49,7 +49,7 @@ func New(opts docopt.Opts) Cli {
 }
 
 func (h Cli) id() *string {
-	idOption, ok := h.Opts[idOption]
+	idOption, ok := h.Opts[optionID]
 	if !ok || idOption == nil {
 		return nil
 	}
@@ -58,12 +58,12 @@ func (h Cli) id() *string {
 }
 
 func (h Cli) encode() (encode, error) {
-	if _, ok := h.Opts[encodeOptionYAML]; !ok {
+	if _, ok := h.Opts[optionEncodeYAML]; !ok {
 		return asyncapiEncode.ToJSON, nil
 	}
-	toYaml, ok := h.Opts[encodeOptionYAML].(bool)
+	toYaml, ok := h.Opts[optionEncodeYAML].(bool)
 	if !ok {
-		return nil, errors.Wrap(errInvalidArgument, encodeOptionYAML)
+		return nil, errors.Wrap(errInvalidArgument, optionEncodeYAML)
 	}
 	if toYaml {
 		return asyncapiEncode.ToYaml, nil
@@ -77,7 +77,7 @@ func isURL(str string) bool {
 }
 
 func (h Cli) reader() (io.Reader, error) {
-	fileOption := h.Opts[fileOptionPath]
+	fileOption := h.Opts[optionFilePath]
 	path := fmt.Sprintf("%v", fileOption)
 	if isURL(path) {
 		resp, err := http.Get(path)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,7 +9,7 @@ import (
 func TestCli_id_error(t *testing.T) {
 	g := NewWithT(t)
 	id := New(map[string]interface{}{
-		"--id": 123,
+		idOption: 123,
 	}).id()
 	g.Expect(*id).To(Equal("123"))
 }
@@ -23,7 +23,7 @@ func TestCli_id_ok(t *testing.T) {
 func TestCli_encode_err(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		"--toYAML": "error",
+		encodeOptionYAML: "error",
 	}).encode()
 	g.Expect(err).Should(HaveOccurred())
 }
@@ -37,7 +37,7 @@ func TestCli_encode_ToJSON(t *testing.T) {
 func TestCli_encode_ToYaml_true(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		"--toYAML": true,
+		encodeOptionYAML: true,
 	}).encode()
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
@@ -45,7 +45,7 @@ func TestCli_encode_ToYaml_true(t *testing.T) {
 func TestCli_encode_ToYaml_false(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		"--toYAML": false,
+		encodeOptionYAML: false,
 	}).encode()
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
@@ -59,7 +59,7 @@ func TestCli_reader_error_no_path(t *testing.T) {
 func TestCli_reader_http_error(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		"<PATH>": "http://atest",
+		fileOptionPath: "http://atest",
 	}).reader()
 	g.Expect(err).Should(HaveOccurred())
 }
@@ -67,7 +67,7 @@ func TestCli_reader_http_error(t *testing.T) {
 func TestCli_reader_file_error(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		"<PATH>": "/invalid/path/to/a/file",
+		fileOptionPath: "/invalid/path/to/a/file",
 	}).reader()
 	g.Expect(err).Should(HaveOccurred())
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,7 +9,7 @@ import (
 func TestCli_id_error(t *testing.T) {
 	g := NewWithT(t)
 	id := New(map[string]interface{}{
-		idOption: 123,
+		optionID: 123,
 	}).id()
 	g.Expect(*id).To(Equal("123"))
 }
@@ -23,7 +23,7 @@ func TestCli_id_ok(t *testing.T) {
 func TestCli_encode_err(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		encodeOptionYAML: "error",
+		optionEncodeYAML: "error",
 	}).encode()
 	g.Expect(err).Should(HaveOccurred())
 }
@@ -37,7 +37,7 @@ func TestCli_encode_ToJSON(t *testing.T) {
 func TestCli_encode_ToYaml_true(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		encodeOptionYAML: true,
+		optionEncodeYAML: true,
 	}).encode()
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
@@ -45,7 +45,7 @@ func TestCli_encode_ToYaml_true(t *testing.T) {
 func TestCli_encode_ToYaml_false(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		encodeOptionYAML: false,
+		optionEncodeYAML: false,
 	}).encode()
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
@@ -59,7 +59,7 @@ func TestCli_reader_error_no_path(t *testing.T) {
 func TestCli_reader_http_error(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		fileOptionPath: "http://atest",
+		optionFilePath: "http://atest",
 	}).reader()
 	g.Expect(err).Should(HaveOccurred())
 }
@@ -67,7 +67,7 @@ func TestCli_reader_http_error(t *testing.T) {
 func TestCli_reader_file_error(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(map[string]interface{}{
-		fileOptionPath: "/invalid/path/to/a/file",
+		optionFilePath: "/invalid/path/to/a/file",
 	}).reader()
 	g.Expect(err).Should(HaveOccurred())
 }


### PR DESCRIPTION
**Description**
There were some literals used as strings, and that is sometimes error-prone.

Changes proposed in this pull request:

I extracted them to consts, that way is easier to change and maintain them 

**Related issue(s)**
https://github.com/asyncapi/converter-go/issues/46

I extracted all the options, but if it was not a great idea I can revert it and extract the only one that is repeated.
Also, if there are any tips to improve my code I'll be happy to address them!
