### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         go: 
-          - '1.14'
-          - '1.13'
-          - '1.12' 
+          - '1.17'
+          - '1.16'
+          - '1.15' 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v1.1.2
+        uses: actions/setup-go@v2
         with:
           go-version: '${{ matrix.go }}'
       - name: Invoking go test
@@ -34,9 +34,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v1.1.2
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.14'
+          go-version: '1.17'
       - name: Invoking go vet and binaries generation
         run: |
           go vet ./...


### PR DESCRIPTION
This PR fixes the release workflow as it is failing right now due to deprecated usage of `set-env` and `add-path`.

Current error can be seen here https://github.com/asyncapi/converter-go/runs/3767238930